### PR TITLE
cleanup makefile unused vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,32 +13,31 @@ CC ?= $(CROSSCOMPILE)-gcc
 
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)
-    # Not crosscompiling, so check that we're on Linux.
-    ifneq ($(shell uname -s),Linux)
-        $(warning raspijpgs only works on Linux on a Raspberry Pi. Crosscompilation)
-        $(warning is supported by defining at least $$CROSSCOMPILE. See Makefile for)
-        $(warning details. If using Nerves, this should be done automatically.)
-        $(warning .)
-        $(warning Skipping C compilation unless targets explicitly passed to make.)
-	DEFAULT_TARGETS = priv
-    else
-        # On the Raspberry Pi, the VideoCore libraries aren't in the standard
-        # locations in /usr/include and /usr/lib.
-	VIDEOCORE_DIR ?= /opt/vc
-
-        ifneq ($(wildcard $(VIDEOCORE_DIR)),)
-	    CFLAGS += -I$(VIDEOCORE_DIR)/include
-            CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vcos/pthreads
-            CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vmcs_host/linux
-            LDFLAGS += -L$(VIDEOCORE_DIR)/lib
-        else
-            $(warning raspijpgs only works on Linux on a Raspberry Pi. The VideoCore)
-            $(warning libraries were not found, so assuming this is a non-Raspberry)
-            $(warning build and skipping C compilation. If this is wrong, check the)
-            $(warning Makefile and define VIDEOCORE_DIR.)
-	    DEFAULT_TARGETS = priv
-        endif
-    endif
+# Not crosscompiling, so check that we're on Linux.
+ifneq ($(shell uname -s),Linux)
+$(warning raspijpgs only works on Linux on a Raspberry Pi. Crosscompilation)
+$(warning is supported by defining at least $$CROSSCOMPILE. See Makefile for)
+$(warning details. If using Nerves, this should be done automatically.)
+$(warning .)
+$(warning Skipping C compilation unless targets explicitly passed to make.)
+DEFAULT_TARGETS = priv
+else
+# On the Raspberry Pi, the VideoCore libraries aren't in the standard
+# locations in /usr/include and /usr/lib.
+VIDEOCORE_DIR ?= /opt/vc
+ifneq ($(wildcard $(VIDEOCORE_DIR)),)
+CFLAGS += -I$(VIDEOCORE_DIR)/include
+CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vcos/pthreads
+CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vmcs_host/linux
+LDFLAGS += -L$(VIDEOCORE_DIR)/lib
+else
+$(warning raspijpgs only works on Linux on a Raspberry Pi. The VideoCore)
+$(warning libraries were not found, so assuming this is a non-Raspberry)
+$(warning build and skipping C compilation. If this is wrong, check the)
+$(warning Makefile and define VIDEOCORE_DIR.)
+DEFAULT_TARGETS = priv
+endif
+endif
 endif
 DEFAULT_TARGETS ?= priv priv/raspijpgs
 
@@ -53,13 +52,13 @@ OBJ=$(SRC:.c=.o)
 all: $(DEFAULT_TARGETS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 priv:
 	mkdir -p priv
 
 priv/raspijpgs: $(OBJ)
-	$(CC) $^ $(LDFLAGS) $(LIBS) -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 clean:
 	rm -f priv/raspijpgs $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -13,31 +13,32 @@ CC ?= $(CROSSCOMPILE)-gcc
 
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)
-# Not crosscompiling, so check that we're on Linux.
-ifneq ($(shell uname -s),Linux)
-$(warning raspijpgs only works on Linux on a Raspberry Pi. Crosscompilation)
-$(warning is supported by defining at least $$CROSSCOMPILE. See Makefile for)
-$(warning details. If using Nerves, this should be done automatically.)
-$(warning .)
-$(warning Skipping C compilation unless targets explicitly passed to make.)
-DEFAULT_TARGETS = priv
-else
-# On the Raspberry Pi, the VideoCore libraries aren't in the standard
-# locations in /usr/include and /usr/lib.
-VIDEOCORE_DIR ?= /opt/vc
-ifneq ($(wildcard $(VIDEOCORE_DIR)),)
-CFLAGS += -I$(VIDEOCORE_DIR)/include
-CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vcos/pthreads
-CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vmcs_host/linux
-LDFLAGS += -L$(VIDEOCORE_DIR)/lib
-else
-$(warning raspijpgs only works on Linux on a Raspberry Pi. The VideoCore)
-$(warning libraries were not found, so assuming this is a non-Raspberry)
-$(warning build and skipping C compilation. If this is wrong, check the)
-$(warning Makefile and define VIDEOCORE_DIR.)
-DEFAULT_TARGETS = priv
-endif
-endif
+    # Not crosscompiling, so check that we're on Linux.
+    ifneq ($(shell uname -s),Linux)
+        $(warning raspijpgs only works on Linux on a Raspberry Pi. Crosscompilation)
+        $(warning is supported by defining at least $$CROSSCOMPILE. See Makefile for)
+        $(warning details. If using Nerves, this should be done automatically.)
+        $(warning .)
+        $(warning Skipping C compilation unless targets explicitly passed to make.)
+	DEFAULT_TARGETS = priv
+    else
+        # On the Raspberry Pi, the VideoCore libraries aren't in the standard
+        # locations in /usr/include and /usr/lib.
+	VIDEOCORE_DIR ?= /opt/vc
+
+        ifneq ($(wildcard $(VIDEOCORE_DIR)),)
+	    CFLAGS += -I$(VIDEOCORE_DIR)/include
+            CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vcos/pthreads
+            CFLAGS += -I$(VIDEOCORE_DIR)/include/interface/vmcs_host/linux
+            LDFLAGS += -L$(VIDEOCORE_DIR)/lib
+        else
+            $(warning raspijpgs only works on Linux on a Raspberry Pi. The VideoCore)
+            $(warning libraries were not found, so assuming this is a non-Raspberry)
+            $(warning build and skipping C compilation. If this is wrong, check the)
+            $(warning Makefile and define VIDEOCORE_DIR.)
+	    DEFAULT_TARGETS = priv
+        endif
+    endif
 endif
 DEFAULT_TARGETS ?= priv priv/raspijpgs
 


### PR DESCRIPTION
- rm undefined INCLUDES and LIBS
- fix conditional block indentation (in Makefile we should not use mixed tab/space indentation). I know it is less readable but conform to Makefiles rules.