### PR TITLE
Support Elixir 1.5 automatic GenServer child_spec

### DIFF
--- a/lib/picam/camera.ex
+++ b/lib/picam/camera.ex
@@ -6,11 +6,11 @@ defmodule Picam.Camera do
   use GenServer
   require Logger
 
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  def init(_) do
+  def init(_opts) do
     executable = Path.join(:code.priv_dir(:picam), "raspijpgs")
 
     port =

--- a/lib/picam/fake_camera.ex
+++ b/lib/picam/fake_camera.ex
@@ -20,12 +20,12 @@ defmodule Picam.FakeCamera do
   require Logger
 
   @doc false
-  def start_link do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   @doc false
-  def init(_) do
+  def init(_opts) do
     state = %{jpg: image_data(1280, 720), fps: 30, requests: []}
     schedule_next_frame(state)
 


### PR DESCRIPTION
This change allows the Elixir 1.5-style built-in `GenServer.child_spec` to work, because it passes in an empty list instead of no parameters to the `start_link` by default.

https://elixir-lang.org/blog/2017/07/25/elixir-v1-5-0-released/#streamlined-child-specs