### PR TITLE
Include sys/uio.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The package can be installed by adding `picam` to your list of dependencies in `
 
 ```elixir
 def deps do
-  [{:picam, "~> 0.2.0"}]
+  [{:picam, "~> 0.4.0"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Picam.Mixfile do
 
   def project do
     [app: :picam,
-     version: "0.4.0-dev",
+     version: "0.4.0",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/src/raspijpgs.c
+++ b/src/raspijpgs.c
@@ -29,6 +29,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <arpa/inet.h> // for ntohl


### PR DESCRIPTION
When using Picam with more recent Nerves versions, it looks like the gcc defaults are different, making `writev` no longer available by default. Explicitly including `sys/uio.h` resolves this.

```
src/raspijpgs.c: In function 'output_jpeg':
src/raspijpgs.c:727:21: warning: implicit declaration of function 'writev'; did you mean 'write'? [-Wimplicit-function-declaration]
     ssize_t count = writev(STDOUT_FILENO, iovs, 2);
                     ^~~~~~
                     write
```

I was going to propose that we release this simple change as a `0.3.1` bugfix, but it looks like there's already also something else merged against the `0.4.0-dev` branch, so we can call it `0.4.0` instead.